### PR TITLE
Removes `contentStyle.css` and its references in manifest.ts

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -28,13 +28,12 @@ const manifest: Manifest.WebExtensionManifest = {
     {
       matches: ['http://*/*', 'https://*/*', '<all_urls>'],
       js: ['src/pages/content/index.js'],
-      css: ['contentStyle.css'],
     },
   ],
   devtools_page: 'src/pages/devtools/index.html',
   web_accessible_resources: [
     {
-      resources: ['contentStyle.css', 'icon-128.png', 'icon-34.png'],
+      resources: ['icon-128.png', 'icon-34.png'],
       matches: [],
     },
   ],


### PR DESCRIPTION
Removes `contentStyle.css` which is no longer used.  I think this was missed by [this PR] which handled other content style cleanup.

Copying the contentStyle.css file into the build directory for content scripts was made irrelevant by [vite-plugin-css-injected-by-js]. This plugin just embeds the css for content scripts directly into the generated `index.js`.

[this PR]: https://github.com/JohnBra/vite-web-extension/pull/13
[vite-plugin-css-injected-by-js]: https://github.com/JohnBra/vite-web-extension/pull/10
