### PR TITLE
Update ci.yml (to use non-deprecated upload-artifact action)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: yarn build:chrome
 
       - name: Upload Chrome extension artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vite-web-extension-chrome
           path: dist_chrome


### PR DESCRIPTION
This updates to v4, as v3 is deprecated (and will actively throw error in CI)
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

> Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). Customers should update workflows to begin using [v4 of the artifact actions](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/) as soon as possible. While v4 of the artifact actions improves upload and download speeds by up to 98% and includes several new features, there are [key differences](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) from previous versions that may require updates to your workflows. Please see [the documentation](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) in the project repositories for guidance on how to migrate your workflows.